### PR TITLE
competency framework - schema attributes validation while review/publish

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
@@ -9,60 +9,82 @@ import org.sunbird.graph.dac.model.Node
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.JavaConverters._
 import org.apache.commons.lang3.StringUtils
+import org.sunbird.common.exception.ClientException
 
 object CompetencyManager {
-    private val defaultValidator = new CompetencyFramework
     private val validators: Map[String, CompetencyValidator] = Map(
         COMPETENCY_FRAMEWORK -> new CompetencyFramework,
         COMPETENCY_LEVEL     -> new CompetencyLevel
     )
 
-    def getValidator(primaryCategory: String): CompetencyValidator = {
-        validators.getOrElse(primaryCategory, defaultValidator)
+    def getValidator(primaryCategory: String): Option[CompetencyValidator] = {
+        Option(primaryCategory).filter(_.nonEmpty).flatMap(validators.get)
     }
 
-    //Validate that the given courseId exists and is of contentType=Course and status=Live.
+    def validateNode(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Unit] = {
+        val metadata = node.getMetadata.asScala
+        val primaryCategory = metadata.getOrElse("primaryCategory", "").toString
+
+        getValidator(primaryCategory) match {
+            case Some(validator) => validator.validate(node).map(Some(_))
+            case None => Future.successful(None)
+        }
+    }
+
+    // Validate that the given courseId exists and is of contentType=Course and status=Live.
     def validateCourseExists(courseId: String, fieldName: String, errors: ListBuffer[String])
                             (implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
         if (StringUtils.isBlank(courseId)) {
-            errors += s"$fieldName courseId is missing"
-            Future.successful(())
+            val msg = s"$fieldName courseId is missing"
+            errors += msg
+            Future.failed(new ClientException("ERR_BLANK_COURSE_ID", msg))
         } else {
             val request = new Request()
-            if (request.getContext == null) {
-                request.setContext(new java.util.HashMap[String, AnyRef]())
+            Option(request.getContext).getOrElse {
+                val context = new java.util.HashMap[String, AnyRef]()
+                request.setContext(context)
+                context
             }
 
-            // Copy metadata from parent node (Competency Level)
-            val parentMetadata = parentNode.getMetadata
-            val graphId        = parentNode.getGraphId.toLowerCase()
-            val channel        = parentMetadata.getOrDefault("channel", "").toString.toLowerCase()
-            val objectType     = parentMetadata.getOrDefault("objectType", "").toString.toLowerCase()
+            val parentMetadata = parentNode.getMetadata.asScala
+            val graphId    = parentMetadata.getOrElse("graphId", parentNode.getGraphId).toString.toLowerCase
+            val channel    = parentMetadata.getOrElse("channel", "").toString.toLowerCase
+            val objectType = parentMetadata.getOrElse("objectType", "").toString.toLowerCase
 
-            request.getContext.put("identifier", courseId)
-            request.getContext.put("graph_id", graphId)
-            request.getContext.put("channel", channel)
-            request.getContext.put("schemaName", objectType)
-            // Hardcoding version to 1.0 (course may not match competency level version)
-            request.getContext.put("version", "1.0")
-            request.getContext.put("objectType", objectType)
-
+            val contextMap = Map[String, AnyRef](
+                "identifier" -> courseId,
+                "graph_id"   -> graphId,
+                "channel"    -> channel,
+                "schemaName" -> objectType,
+                "version"    -> "1.0",
+                "objectType" -> objectType
+            )
+            contextMap.foreach { case (k,v) => request.getContext.put(k,v) }
             request.put("identifier", courseId)
             request.put("objectType", objectType)
 
-            DataNode.read(request).map { node =>
+            DataNode.read(request).flatMap { node =>
                 if (node == null) {
-                    errors += s"$fieldName courseId $courseId not found"
+                    val msg = s"$fieldName courseId $courseId not found"
+                    errors += msg
+                    Future.failed(new ClientException("ERR_COURSE_NOT_FOUND", msg))
                 } else {
-                    val metadata    = node.getMetadata
-                    val status      = metadata.getOrDefault("status", "").toString
-                    val contentType = metadata.getOrDefault("contentType", "").toString
+                    val metadata    = node.getMetadata.asScala
+                    val status      = metadata.getOrElse("status", "").toString
+                    val contentType = metadata.getOrElse("contentType", "").toString
 
                     if (!"Course".equalsIgnoreCase(contentType)) {
-                        errors += s"$fieldName courseId $courseId has invalid contentType: $contentType (expected Course)"
+                        val msg = s"$fieldName courseId $courseId has invalid contentType: $contentType (expected Course)"
+                        errors += msg
+                        Future.failed(new ClientException("ERR_INVALID_CONTENT_TYPE", msg))
                     } else if (!"Live".equalsIgnoreCase(status)) {
-                        errors += s"$fieldName courseId $courseId has invalid status: $status (expected Live)"
+                        val msg = s"$fieldName courseId $courseId has invalid status: $status (expected Live)"
+                        errors += msg
+                        Future.failed(new ClientException("ERR_INVALID_STATUS", msg))
+                    } else {
+                        Future.unit
                     }
                 }
             }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
@@ -1,6 +1,17 @@
 package org.sunbird.content.competency.mgr
+
 import org.sunbird.content.competency.mgr.validator.{CompetencyFramework, CompetencyValidator, CompetencyLevel}
 import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
+import org.sunbird.common.dto.Request
+import org.sunbird.graph.OntologyEngineContext
+import org.sunbird.graph.nodes.DataNode
+import org.sunbird.graph.dac.model.Node
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+
+import org.apache.commons.lang3.StringUtils
+
 
 object CompetencyManager {
     private val defaultValidator = new CompetencyFramework
@@ -11,5 +22,50 @@ object CompetencyManager {
 
     def getValidator(primaryCategory: String): CompetencyValidator = {
         validators.getOrElse(primaryCategory, defaultValidator)
+    }
+    
+    // Validate that the given courseId exists and is of contentType Course and status Live
+    def validateCourseExists(courseId: String, fieldName: String, errors: ListBuffer[String])
+                                    (implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
+        if (StringUtils.isBlank(courseId)) {
+            errors += s"$fieldName courseId is missing"
+        } else {
+            val request = new Request()
+            if (request.getContext == null) {
+                request.setContext(new java.util.HashMap[String, AnyRef]())
+            }
+            // Copy metadata from parent node (Competency Level)
+            val parentMetadata = parentNode.getMetadata
+            val graphId        = parentNode.getGraphId.toLowerCase()
+            val channel        = parentMetadata.getOrDefault("channel", "").toString.toLowerCase()
+            val objectType     = parentMetadata.getOrDefault("objectType", "").toString.toLowerCase()
+            // val version        = parentMetadata.getOrDefault("version", "").toString.toLowerCase()
+
+            request.getContext.put("identifier", courseId)
+            request.getContext.put("graph_id", graphId)
+            request.getContext.put("channel", channel)
+            request.getContext.put("schemaName", objectType)
+            // We are hardcoding version to 1.0 as we may not have same version for course as that of competency level
+            request.getContext.put("version", "1.0")
+            request.getContext.put("objectType", objectType)
+
+            request.put("identifier", courseId)
+            request.put("objectType", objectType)
+
+            DataNode.read(request).map { node =>
+                if (node == null) {
+                    errors += s"$fieldName courseId $courseId not found"
+                } else {
+                    val metadata = node.getMetadata
+                    val status = metadata.getOrDefault("status", "").toString
+                    val contentType = metadata.getOrDefault("contentType", "").toString
+                    if (!"Course".equalsIgnoreCase(contentType)) {
+                        errors += s"$fieldName courseId $courseId has invalid contentType: $contentType (expected Course)"
+                    } else if (!"Live".equalsIgnoreCase(status)) {
+                        errors += s"$fieldName courseId $courseId has invalid status: $status (expected Live)"
+                    }
+                }
+            }
+        }
     }
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
@@ -8,10 +8,8 @@ import org.sunbird.graph.nodes.DataNode
 import org.sunbird.graph.dac.model.Node
 
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext
-
+import scala.concurrent.{ExecutionContext, Future}
 import org.apache.commons.lang3.StringUtils
-
 
 object CompetencyManager {
     private val defaultValidator = new CompetencyFramework
@@ -23,29 +21,30 @@ object CompetencyManager {
     def getValidator(primaryCategory: String): CompetencyValidator = {
         validators.getOrElse(primaryCategory, defaultValidator)
     }
-    
-    // Validate that the given courseId exists and is of contentType Course and status Live
+
+    //Validate that the given courseId exists and is of contentType=Course and status=Live.
     def validateCourseExists(courseId: String, fieldName: String, errors: ListBuffer[String])
-                                    (implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
+                            (implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
         if (StringUtils.isBlank(courseId)) {
             errors += s"$fieldName courseId is missing"
+            Future.successful(())
         } else {
             val request = new Request()
             if (request.getContext == null) {
                 request.setContext(new java.util.HashMap[String, AnyRef]())
             }
+
             // Copy metadata from parent node (Competency Level)
             val parentMetadata = parentNode.getMetadata
             val graphId        = parentNode.getGraphId.toLowerCase()
             val channel        = parentMetadata.getOrDefault("channel", "").toString.toLowerCase()
             val objectType     = parentMetadata.getOrDefault("objectType", "").toString.toLowerCase()
-            // val version        = parentMetadata.getOrDefault("version", "").toString.toLowerCase()
 
             request.getContext.put("identifier", courseId)
             request.getContext.put("graph_id", graphId)
             request.getContext.put("channel", channel)
             request.getContext.put("schemaName", objectType)
-            // We are hardcoding version to 1.0 as we may not have same version for course as that of competency level
+            // Hardcoding version to 1.0 (course may not match competency level version)
             request.getContext.put("version", "1.0")
             request.getContext.put("objectType", objectType)
 
@@ -56,9 +55,10 @@ object CompetencyManager {
                 if (node == null) {
                     errors += s"$fieldName courseId $courseId not found"
                 } else {
-                    val metadata = node.getMetadata
-                    val status = metadata.getOrDefault("status", "").toString
+                    val metadata    = node.getMetadata
+                    val status      = metadata.getOrDefault("status", "").toString
                     val contentType = metadata.getOrDefault("contentType", "").toString
+
                     if (!"Course".equalsIgnoreCase(contentType)) {
                         errors += s"$fieldName courseId $courseId has invalid contentType: $contentType (expected Course)"
                     } else if (!"Live".equalsIgnoreCase(status)) {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
@@ -1,0 +1,15 @@
+package org.sunbird.content.competency.mgr
+import org.sunbird.content.competency.mgr.validator.{CompetencyFramework, CompetencyValidator, CompetencyLevel}
+import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
+
+object CompetencyManager {
+    private val defaultValidator = new CompetencyFramework
+    private val validators: Map[String, CompetencyValidator] = Map(
+        COMPETENCY_FRAMEWORK -> new CompetencyFramework,
+        COMPETENCY_LEVEL     -> new CompetencyLevel
+    )
+
+    def getValidator(primaryCategory: String): CompetencyValidator = {
+        validators.getOrElse(primaryCategory, defaultValidator)
+    }
+}

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/CompetencyManager.scala
@@ -33,13 +33,13 @@ object CompetencyManager {
         }
     }
 
-    // Validate that the given courseId exists and is of contentType=Course and status=Live.
-    def validateCourseExists(courseId: String, fieldName: String, errors: ListBuffer[String])
+    // Validate that the given collectionId exists and is of contentType=Course and status=Live.
+    def validateCourseExists(collectionId: String, fieldName: String, errors: ListBuffer[String])
                             (implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
-        if (StringUtils.isBlank(courseId)) {
-            val msg = s"$fieldName courseId is missing"
+        if (StringUtils.isBlank(collectionId)) {
+            val msg = s"$fieldName collectionId is missing"
             errors += msg
-            Future.failed(new ClientException("ERR_BLANK_COURSE_ID", msg))
+            Future.failed(new ClientException("ERR_BLANK_COLLECTION_ID", msg))
         } else {
             val request = new Request()
             Option(request.getContext).getOrElse {
@@ -54,7 +54,7 @@ object CompetencyManager {
             val objectType = parentMetadata.getOrElse("objectType", "").toString.toLowerCase
 
             val contextMap = Map[String, AnyRef](
-                "identifier" -> courseId,
+                "identifier" -> collectionId,
                 "graph_id"   -> graphId,
                 "channel"    -> channel,
                 "schemaName" -> objectType,
@@ -62,25 +62,25 @@ object CompetencyManager {
                 "objectType" -> objectType
             )
             contextMap.foreach { case (k,v) => request.getContext.put(k,v) }
-            request.put("identifier", courseId)
+            request.put("identifier", collectionId)
             request.put("objectType", objectType)
 
             DataNode.read(request).flatMap { node =>
                 if (node == null) {
-                    val msg = s"$fieldName courseId $courseId not found"
+                    val msg = s"$fieldName collectionId $collectionId not found"
                     errors += msg
-                    Future.failed(new ClientException("ERR_COURSE_NOT_FOUND", msg))
+                    Future.failed(new ClientException("ERR_COLLECTION_NOT_FOUND", msg))
                 } else {
                     val metadata    = node.getMetadata.asScala
                     val status      = metadata.getOrElse("status", "").toString
                     val contentType = metadata.getOrElse("contentType", "").toString
 
                     if (!"Course".equalsIgnoreCase(contentType)) {
-                        val msg = s"$fieldName courseId $courseId has invalid contentType: $contentType (expected Course)"
+                        val msg = s"$fieldName collectionId $collectionId has invalid contentType: $contentType (expected Course)"
                         errors += msg
                         Future.failed(new ClientException("ERR_INVALID_CONTENT_TYPE", msg))
                     } else if (!"Live".equalsIgnoreCase(status)) {
-                        val msg = s"$fieldName courseId $courseId has invalid status: $status (expected Live)"
+                        val msg = s"$fieldName collectionId $collectionId has invalid status: $status (expected Live)"
                         errors += msg
                         Future.failed(new ClientException("ERR_INVALID_STATUS", msg))
                     } else {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -5,22 +5,6 @@ object CompetencyConstants {
     val COMPETENCY_FRAMEWORK: String = "Competency Framework"
     val COMPETENCY_LEVEL: String     = "Competency Level"
 
-    // Schema attributes
-    val SIGNUP_BY_ADMIN: String = "Admin"
-    val SIGNUP_BY_USER: String  = "User"
-    val VALID_SIGNUP_BY: Set[String] = Set(SIGNUP_BY_ADMIN, SIGNUP_BY_USER)
-
-    val ENROLLMENT_FULL: String     = "Full Enrollment"
-    val ENROLLMENT_ENTRANCE: String = "Entrance Exam Based"
-    val ENROLLMENT_PROGRESS: String = "Progress Based"
-    val VALID_ENROLLMENT_TYPES: Set[String] = Set(ENROLLMENT_FULL, ENROLLMENT_ENTRANCE, ENROLLMENT_PROGRESS)
-
-    val SECTOR: String = "Education"
-    val DOMAIN: String = "Preschool"
-    val VALID_SECTORS: Set[String] = Set(SECTOR)
-    val VALID_DOMAINS: Set[String] = Set(DOMAIN)
-
-    val VALID_LEVEL_NAMES: Set[String] = Set("Beginner", "Intermediate", "Advanced")
 
     val TIME_LIMIT_ENABLED: String = "enabled"
     val TIME_LIMIT_DURATION: String = "duration"
@@ -31,42 +15,14 @@ object CompetencyConstants {
 
     val ENTRANCE_EXAM_ENABLED: String = "enabled"
     val ENTRANCE_EXAM_COURSE_ID: String  = "courseId"
-    val ENTRANCE_EXAM_VALID: Set[String] = Set("Yes", "No")
 
     val LEVEL_EXAM_COURSE_ID: String = "courseId"
-    val PASSING_CRITERIA: String  = "passingCriteria"
-    val PASSING_CRITERIA_MUST_PASS: String = "mustPass"
-    val PASSING_CRITERIA_VALID: Set[String] = Set("Yes", "No")
-
-    val REQUIRED_COMPETENCY_FRAMEWORK_FIELDS: List[String] = List(
-        "sector",
-        "signupBy",
-        "enrollmentType"
-    )
-
-    val REQUIRED_COMPETENCY_LEVEL_FIELDS: List[String] = List(
-        "name",
-        "timeLimit",
-        "entranceExam",
-        "levelExam"
-    )
 
 }
 
 object CompetencyErrorMessages {
+
     import CompetencyConstants._
-
-    def invalidLevelName(value: String): String =
-        s"Invalid name: $value (must be one of ${VALID_LEVEL_NAMES.mkString(", ")})"
-
-    def missingTimeLimitValue(): String =
-        s"$TIME_LIMIT_DURATION.$TIME_LIMIT_VALUE is required when $TIME_LIMIT_ENABLED=$TIME_LIMIT_YES"
-
-    def missingTimeLimitUnit(): String =
-        s"$TIME_LIMIT_DURATION.$TIME_LIMIT_UNIT is required when $TIME_LIMIT_ENABLED=$TIME_LIMIT_YES"
-
-    def invalidEntranceExamEnabled(value: String): String =
-        s"entranceExam.$ENTRANCE_EXAM_ENABLED must be one of ${ENTRANCE_EXAM_VALID.mkString(", ")}"
 
     def missingEntranceExamCourseId(): String =
         s"entranceExam.$ENTRANCE_EXAM_COURSE_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_LIMIT_YES"
@@ -74,18 +30,4 @@ object CompetencyErrorMessages {
     def missingLevelExamCourseId(): String =
         s"levelExam.$LEVEL_EXAM_COURSE_ID is required"
 
-    def invalidPassingCriteria(value: String): String =
-        s"levelExam.$PASSING_CRITERIA.$PASSING_CRITERIA_MUST_PASS '$value' must be one of ${PASSING_CRITERIA_VALID.mkString(", ")}"
-
-    def invalidSignupBy(value: String): String =
-        s"Invalid signupBy: $value (must be one of ${VALID_SIGNUP_BY.mkString(", ")})"
-
-    def invalidEnrollmentType(value: String): String =
-        s"Invalid enrollmentType: $value (must be one of ${VALID_ENROLLMENT_TYPES.mkString(", ")})"
-
-    def invalidSectorName(value: String): String =
-        s"Invalid sector.name: $value (must be one of ${VALID_SECTORS.mkString(", ")})"
-
-    def invalidSectorDomain(value: String): String =
-        s"Invalid sector.domain: $value (must be one of ${VALID_DOMAINS.mkString(", ")})"
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -9,8 +9,8 @@ object CompetencyConstants {
     val TIME_LIMIT_DURATION: String = "duration"
     val TIME_LIMIT_VALUE: String    = "value"
     val TIME_LIMIT_UNIT: String     = "unit"
-    val TIME_LIMIT_YES: String      = "Yes"
-    val TIME_LIMIT_NO: String       = "No"
+    val TIME_YES: String      = "Yes"
+    val TIME_NO: String       = "No"
 
     val ENTRANCE_EXAM_ENABLED: String = "enabled"
     val ENTRANCE_EXAM_COURSE_ID: String  = "courseId"
@@ -24,7 +24,7 @@ object CompetencyErrorMessages {
     import CompetencyConstants._
 
     def missingEntranceExamCourseId(): String =
-        s"entranceExam.$ENTRANCE_EXAM_COURSE_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_LIMIT_YES"
+        s"entranceExam.$ENTRANCE_EXAM_COURSE_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_YES"
 
     def missingLevelExamCourseId(): String =
         s"levelExam.$LEVEL_EXAM_COURSE_ID is required"

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -4,7 +4,6 @@ object CompetencyConstants {
     val COMPETENCY_FRAMEWORK: String = "Competency Framework"
     val COMPETENCY_LEVEL: String     = "Competency Level"
 
-
     val TIME_LIMIT_ENABLED: String = "enabled"
     val TIME_LIMIT_DURATION: String = "duration"
     val TIME_LIMIT_VALUE: String    = "value"
@@ -16,11 +15,9 @@ object CompetencyConstants {
     val ENTRANCE_EXAM_COURSE_ID: String  = "courseId"
 
     val LEVEL_EXAM_COURSE_ID: String = "courseId"
-
 }
 
 object CompetencyErrorMessages {
-
     import CompetencyConstants._
 
     def missingEntranceExamCourseId(): String =
@@ -28,5 +25,4 @@ object CompetencyErrorMessages {
 
     def missingLevelExamCourseId(): String =
         s"levelExam.$LEVEL_EXAM_COURSE_ID is required"
-
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -12,17 +12,17 @@ object CompetencyConstants {
     val TIME_NO: String       = "No"
 
     val ENTRANCE_EXAM_ENABLED: String = "enabled"
-    val ENTRANCE_EXAM_COURSE_ID: String  = "courseId"
+    val ENTRANCE_EXAM_COLLECTION_ID: String  = "collectionId"
 
-    val LEVEL_EXAM_COURSE_ID: String = "courseId"
+    val LEVEL_EXAM_COLLECTION_ID: String = "collectionId"
 }
 
 object CompetencyErrorMessages {
     import CompetencyConstants._
 
-    def missingEntranceExamCourseId(): String =
-        s"entranceExam.$ENTRANCE_EXAM_COURSE_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_YES"
+    def missingEntranceExamCollectionId(): String =
+        s"entranceExam.$ENTRANCE_EXAM_COLLECTION_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_YES"
 
-    def missingLevelExamCourseId(): String =
-        s"levelExam.$LEVEL_EXAM_COURSE_ID is required"
+    def missingLevelExamCollectionId(): String =
+        s"levelExam.$LEVEL_EXAM_COLLECTION_ID is required"
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -1,0 +1,91 @@
+package org.sunbird.content.competency.mgr.constants
+
+object CompetencyConstants {
+    // Primary categories
+    val COMPETENCY_FRAMEWORK: String = "Competency Framework"
+    val COMPETENCY_LEVEL: String     = "Competency Level"
+
+    // Schema attributes
+    val SIGNUP_BY_ADMIN: String = "Admin"
+    val SIGNUP_BY_USER: String  = "User"
+    val VALID_SIGNUP_BY: Set[String] = Set(SIGNUP_BY_ADMIN, SIGNUP_BY_USER)
+
+    val ENROLLMENT_FULL: String     = "Full Enrollement"
+    val ENROLLMENT_ENTRANCE: String = "Entrance Exam Based"
+    val ENROLLMENT_PROGRESS: String = "Progress Based"
+    val VALID_ENROLLMENT_TYPES: Set[String] = Set(ENROLLMENT_FULL, ENROLLMENT_ENTRANCE, ENROLLMENT_PROGRESS)
+
+    val SECTOR: String = "Education"
+    val DOMAIN: String = "Preschool"
+    val VALID_SECTORS: Set[String] = Set(SECTOR)
+    val VALID_DOMAINS: Set[String] = Set(DOMAIN)
+
+    val VALID_LEVEL_NAMES: Set[String] = Set("Beginner", "Intermediate", "Advanced")
+
+    val TIME_LIMIT_ENABLED: String = "enabled"
+    val TIME_LIMIT_DURATION: String = "duration"
+    val TIME_LIMIT_VALUE: String    = "value"
+    val TIME_LIMIT_UNIT: String     = "unit"
+    val TIME_LIMIT_YES: String      = "Yes"
+    val TIME_LIMIT_NO: String       = "No"
+
+    val ENTRANCE_EXAM_ENABLED: String = "enabled"
+    val ENTRANCE_EXAM_COURSE_ID: String  = "courseId"
+    val ENTRANCE_EXAM_VALID: Set[String] = Set("Yes", "No")
+
+    val LEVEL_EXAM_COURSE_ID: String = "courseId"
+    val PASSING_CRITERIA: String  = "passingCriteria"
+    val PASSING_CRITERIA_MUST_PASS: String = "mustPass"
+    val PASSING_CRITERIA_VALID: Set[String] = Set("Yes", "No")
+
+    val REQUIRED_COMPETENCY_FRAMEWORK_FIELDS: List[String] = List(
+        "sector",
+        "signupBy",
+        "enrollmentType"
+    )
+
+    val REQUIRED_COMPETENCY_LEVEL_FIELDS: List[String] = List(
+        "name",
+        "timeLimit",
+        "entranceExam",
+        "levelExam"
+    )
+
+}
+
+object CompetencyErrorMessages {
+    import CompetencyConstants._
+
+    def invalidLevelName(value: String): String =
+        s"Invalid name: $value (must be one of ${VALID_LEVEL_NAMES.mkString(", ")})"
+
+    def missingTimeLimitValue(): String =
+        s"$TIME_LIMIT_DURATION.$TIME_LIMIT_VALUE is required when $TIME_LIMIT_ENABLED=$TIME_LIMIT_YES"
+
+    def missingTimeLimitUnit(): String =
+        s"$TIME_LIMIT_DURATION.$TIME_LIMIT_UNIT is required when $TIME_LIMIT_ENABLED=$TIME_LIMIT_YES"
+
+    def invalidEntranceExamEnabled(value: String): String =
+        s"entranceExam.$ENTRANCE_EXAM_ENABLED must be one of ${ENTRANCE_EXAM_VALID.mkString(", ")}"
+
+    def missingEntranceExamCourseId(): String =
+        s"entranceExam.$ENTRANCE_EXAM_COURSE_ID is required when $ENTRANCE_EXAM_ENABLED=$TIME_LIMIT_YES"
+
+    def missingLevelExamCourseId(): String =
+        s"levelExam.$LEVEL_EXAM_COURSE_ID is required"
+
+    def invalidPassingCriteria(value: String): String =
+        s"levelExam.$PASSING_CRITERIA.$PASSING_CRITERIA_MUST_PASS '$value' must be one of ${PASSING_CRITERIA_VALID.mkString(", ")}"
+
+    def invalidSignupBy(value: String): String =
+        s"Invalid signupBy: $value (must be one of ${VALID_SIGNUP_BY.mkString(", ")})"
+
+    def invalidEnrollmentType(value: String): String =
+        s"Invalid enrollmentType: $value (must be one of ${VALID_ENROLLMENT_TYPES.mkString(", ")})"
+
+    def invalidSectorName(value: String): String =
+        s"Invalid sector.name: $value (must be one of ${VALID_SECTORS.mkString(", ")})"
+
+    def invalidSectorDomain(value: String): String =
+        s"Invalid sector.domain: $value (must be one of ${VALID_DOMAINS.mkString(", ")})"
+}

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -1,7 +1,6 @@
 package org.sunbird.content.competency.mgr.constants
 
 object CompetencyConstants {
-    // Primary categories
     val COMPETENCY_FRAMEWORK: String = "Competency Framework"
     val COMPETENCY_LEVEL: String     = "Competency Level"
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/constants/CompetencyConstants.scala
@@ -10,7 +10,7 @@ object CompetencyConstants {
     val SIGNUP_BY_USER: String  = "User"
     val VALID_SIGNUP_BY: Set[String] = Set(SIGNUP_BY_ADMIN, SIGNUP_BY_USER)
 
-    val ENROLLMENT_FULL: String     = "Full Enrollement"
+    val ENROLLMENT_FULL: String     = "Full Enrollment"
     val ENROLLMENT_ENTRANCE: String = "Entrance Exam Based"
     val ENROLLMENT_PROGRESS: String = "Progress Based"
     val VALID_ENROLLMENT_TYPES: Set[String] = Set(ENROLLMENT_FULL, ENROLLMENT_ENTRANCE, ENROLLMENT_PROGRESS)

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -7,15 +7,15 @@ import org.sunbird.common.exception.ClientException
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import com.google.gson.Gson
 
 class CompetencyFramework extends CompetencyValidator {
 
     private val gson = new Gson()
-    val logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
+    val logger: Logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node): Either[List[String], Unit] = {
+    override def validate(node: Node): Unit = {
         val errors = ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -2,18 +2,22 @@ package org.sunbird.content.competency.mgr.validator
 
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.common.exception.ClientException
+import org.sunbird.graph.OntologyEngineContext
 
+import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+
 import org.slf4j.{Logger, LoggerFactory}
 import com.google.gson.Gson
 
 class CompetencyFramework extends CompetencyValidator {
 
     private val gson = new Gson()
-    val logger: Logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
+    val logger: Logger =
+        LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node): Unit = {
+    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit = {
         val errors = ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -1,0 +1,64 @@
+package org.sunbird.content.competency.mgr.validator
+
+import org.sunbird.graph.dac.model.Node
+import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
+import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
+import org.sunbird.common.exception.ClientException
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import com.google.gson.Gson
+
+class CompetencyFramework extends CompetencyValidator {
+
+    private val gson = new Gson()
+
+    override def validate(node: Node): Either[List[String], Unit] = {
+        val errors = ListBuffer[String]()
+        val metadata = node.getMetadata.asScala.toMap
+
+        REQUIRED_COMPETENCY_FRAMEWORK_FIELDS.foreach { field =>
+            if (!metadata.contains(field) || metadata(field) == null || metadata(field).toString.trim.isEmpty) {
+                errors += s"Missing or empty required field: $field"
+            }
+        }
+
+        metadata.get("sector").foreach {
+            case m: java.util.Map[_, _] =>
+                val sector = m.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+                validateSector(sector, errors)
+            case s: String =>
+                val sector = gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
+                validateSector(sector, errors)
+            case other =>
+                println(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
+        }
+
+        metadata.get("signupBy").foreach { value =>
+            val signupBy = value.toString
+            if (!VALID_SIGNUP_BY.contains(signupBy))
+                errors += invalidSignupBy(signupBy)
+        }
+
+        metadata.get("enrollmentType").foreach { value =>
+            val enrollmentType = value.toString
+            if (!VALID_ENROLLMENT_TYPES.contains(enrollmentType))
+                errors += invalidEnrollmentType(enrollmentType)
+        }
+
+        if (errors.nonEmpty) {
+            throw new ClientException("ERR_COMPETENCY_FRAMEWORK_REVIEW", "Competency Framework: " + errors.mkString("; "))
+        } else Right(())
+    }
+
+    private def validateSector(sector: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
+        val name   = sector.getOrElse("name", "").toString
+        val domain = sector.getOrElse("domain", "").toString
+
+        if (!VALID_SECTORS.contains(name))
+            errors += invalidSectorName(name)
+
+        if (!VALID_DOMAINS.contains(domain))
+            errors += invalidSectorDomain(domain)
+    }
+}

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -49,8 +49,8 @@ class CompetencyFramework extends CompetencyValidator {
         }
 
         if (errors.nonEmpty) {
-            throw new ClientException("ERR_COMPETENCY_FRAMEWORK_REVIEW", "Competency Framework: " + errors.mkString("; "))
-        } else Right(())
+            throw new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Framework: " + errors.mkString("; "))
+        }
     }
 
     private def validateSector(sector: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -3,48 +3,60 @@ package org.sunbird.content.competency.mgr.validator
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.OntologyEngineContext
+import org.sunbird.common.JsonUtils
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+import scala.util.{Try, Success, Failure}
 
 import org.slf4j.{Logger, LoggerFactory}
-import com.google.gson.Gson
 
 class CompetencyFramework extends CompetencyValidator {
 
-    private val gson = new Gson()
     val logger: Logger =
         LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit = {
+    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Unit] = {
         val errors = ListBuffer[String]()
-        val metadata = node.getMetadata.asScala.toMap
+        val metadata = node.getMetadata.asScala
 
-        metadata.get("sector").foreach {
-            case m: java.util.Map[_, _] =>
-                val sector = m.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
-                validateSector(sector, errors)
-            case s: String =>
-                val sector = gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
-                validateSector(sector, errors)
-            case other =>
-                logger.warn(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
+        val sector = metadata.getOrElse("sector", null)
+        if (sector != null) {
+            sector match {
+                case m: java.util.Map[_, _] =>
+                    val sectorMap = m.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+                    validateSector(sectorMap, errors)
+                case s: String =>
+                    Try(JsonUtils.deserialize(s, classOf[java.util.Map[String, AnyRef]])) match {
+                        case Success(sectorMap) =>
+                            val sectorMapScala = sectorMap.asScala.toMap
+                            validateSector(sectorMapScala, errors)
+                        case Failure(ex) =>
+                            logger.error(s"[COMPETENCY-FRAMEWORK] Failed to parse sector JSON: $s", ex)
+                            errors += "Invalid sector JSON format"
+                    }
+                case other =>
+                    logger.warn(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
+                    errors += s"Invalid sector type: ${other.getClass.getSimpleName}"
+            }
         }
 
         if (errors.nonEmpty) {
-            throw new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Framework: " + errors.mkString("; "))
+            Future.failed(new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Framework: " + errors.mkString("; ")))
+        } else {
+            Future.unit
         }
     }
 
     private def validateSector(sector: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
-        val name   = sector.getOrElse("name", "").toString
-        val domain = sector.getOrElse("domain", "").toString
+        val name = sector.getOrElse("name", "").toString.trim
+        val domain = sector.getOrElse("domain", "").toString.trim
 
-        if (name.trim.isEmpty)
+        if (name.isEmpty)
             errors += "sector.name is required"
 
-        if (domain.trim.isEmpty)
+        if (domain.isEmpty)
             errors += "sector.domain is required"
     }
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -7,11 +7,13 @@ import org.sunbird.common.exception.ClientException
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
+import org.slf4j.LoggerFactory
 import com.google.gson.Gson
 
 class CompetencyFramework extends CompetencyValidator {
 
     private val gson = new Gson()
+    val logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
     override def validate(node: Node): Either[List[String], Unit] = {
         val errors = ListBuffer[String]()
@@ -31,7 +33,7 @@ class CompetencyFramework extends CompetencyValidator {
                 val sector = gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
                 validateSector(sector, errors)
             case other =>
-                println(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
+                logger.warn(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
         }
 
         metadata.get("signupBy").foreach { value =>

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -19,12 +19,6 @@ class CompetencyFramework extends CompetencyValidator {
         val errors = ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
 
-        REQUIRED_COMPETENCY_FRAMEWORK_FIELDS.foreach { field =>
-            if (!metadata.contains(field) || metadata(field) == null || metadata(field).toString.trim.isEmpty) {
-                errors += s"Missing or empty required field: $field"
-            }
-        }
-
         metadata.get("sector").foreach {
             case m: java.util.Map[_, _] =>
                 val sector = m.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
@@ -36,18 +30,6 @@ class CompetencyFramework extends CompetencyValidator {
                 logger.warn(s"[COMPETENCY-FRAMEWORK] sector unknown type: ${other.getClass} => $other")
         }
 
-        metadata.get("signupBy").foreach { value =>
-            val signupBy = value.toString
-            if (!VALID_SIGNUP_BY.contains(signupBy))
-                errors += invalidSignupBy(signupBy)
-        }
-
-        metadata.get("enrollmentType").foreach { value =>
-            val enrollmentType = value.toString
-            if (!VALID_ENROLLMENT_TYPES.contains(enrollmentType))
-                errors += invalidEnrollmentType(enrollmentType)
-        }
-
         if (errors.nonEmpty) {
             throw new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Framework: " + errors.mkString("; "))
         }
@@ -57,10 +39,10 @@ class CompetencyFramework extends CompetencyValidator {
         val name   = sector.getOrElse("name", "").toString
         val domain = sector.getOrElse("domain", "").toString
 
-        if (!VALID_SECTORS.contains(name))
-            errors += invalidSectorName(name)
+        if (name.trim.isEmpty)
+            errors += "sector.name is required"
 
-        if (!VALID_DOMAINS.contains(domain))
-            errors += invalidSectorDomain(domain)
+        if (domain.trim.isEmpty)
+            errors += "sector.domain is required"
     }
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyFramework.scala
@@ -1,8 +1,6 @@
 package org.sunbird.content.competency.mgr.validator
 
 import org.sunbird.graph.dac.model.Node
-import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
-import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
 import org.sunbird.common.exception.ClientException
 
 import scala.collection.JavaConverters._

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -6,14 +6,14 @@ import org.sunbird.graph.dac.model.Node
 
 import scala.collection.JavaConverters._
 import com.google.gson.Gson
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 class CompetencyLevel extends CompetencyValidator {
 
     private val gson = new Gson()
-    val logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
+    val logger: Logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node): Either[List[String], Unit] = {
+    override def validate(node: Node): Unit = {
         val errors = scala.collection.mutable.ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -121,6 +121,14 @@ class CompetencyLevel extends CompetencyValidator {
 
             if (value.isEmpty) {
                 errors += s"timeLimit.duration.$TIME_LIMIT_VALUE is required"
+            } else {
+                // Validate that the value is a number
+                try {
+                    value.toDouble
+                } catch {
+                    case _: NumberFormatException =>
+                        errors += s"timeLimit.duration.$TIME_LIMIT_VALUE must be a valid number"
+                }
             }
 
             if (unit.isEmpty) {
@@ -134,12 +142,12 @@ class CompetencyLevel extends CompetencyValidator {
                                      metadata: Map[String, AnyRef],
                                      errors: ListBuffer[String]
                                  )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
-        val courseId = exam.getOrElse(LEVEL_EXAM_COURSE_ID, "").toString.trim
-        if (courseId.isEmpty) {
-            errors += missingLevelExamCourseId()
+        val collectionId = exam.getOrElse(LEVEL_EXAM_COLLECTION_ID, "").toString.trim
+        if (collectionId.isEmpty) {
+            errors += missingLevelExamCollectionId()
             Future.unit
         } else {
-            validateCourseExists(courseId, "Level Exam", errors)
+            validateCourseExists(collectionId, "Level Exam", errors)
         }
     }
 
@@ -149,12 +157,12 @@ class CompetencyLevel extends CompetencyValidator {
                                     )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
         val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, TIME_NO).toString
         if (enabled == TIME_YES) {
-            val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString.trim
-            if (courseId.isEmpty) {
-                errors += missingEntranceExamCourseId()
+            val collectionId = exam.getOrElse(ENTRANCE_EXAM_COLLECTION_ID, "").toString.trim
+            if (collectionId.isEmpty) {
+                errors += missingEntranceExamCollectionId()
                 Future.unit
             } else {
-                validateCourseExists(courseId, "Entrance Exam", errors)
+                validateCourseExists(collectionId, "Entrance Exam", errors)
             }
         } else {
             Future.unit

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -1,0 +1,100 @@
+package org.sunbird.content.competency.mgr.validator
+import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
+import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
+import org.sunbird.common.exception.ClientException
+import org.sunbird.graph.dac.model.Node
+
+import scala.collection.JavaConverters._
+import com.google.gson.Gson
+
+class CompetencyLevel extends CompetencyValidator {
+
+    private val gson = new Gson()
+
+    override def validate(node: Node): Either[List[String], Unit] = {
+        val errors = scala.collection.mutable.ListBuffer[String]()
+        val metadata = node.getMetadata.asScala.toMap
+
+        REQUIRED_COMPETENCY_LEVEL_FIELDS.foreach { field =>
+            if (!metadata.contains(field) || metadata(field) == null || metadata(field).toString.trim.isEmpty) {
+                errors += s"Missing or empty required field: $field"
+            }
+        }
+
+        metadata.get("name").foreach { name =>
+            if (!VALID_LEVEL_NAMES.contains(name.toString))
+                errors += invalidLevelName(name.toString)
+        }
+
+        metadata.get("timeLimit").foreach {
+            case tl: java.util.Map[_, _] =>
+                validateTimeLimit(tl.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, errors)
+            case s: String =>
+                validateTimeLimit(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
+            case other =>
+                println(s"[COMPETENCY-FRAMEWORK] timeLimit unknown type: ${other.getClass} => $other")
+        }
+
+        metadata.get("entranceExam").foreach {
+            case ee: java.util.Map[_, _] =>
+                validateEntranceExam(ee.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, errors)
+            case s: String =>
+                validateEntranceExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
+            case other =>
+                println(s"[COMPETENCY-FRAMEWORK] entranceExam unknown type: ${other.getClass} => $other")
+        }
+
+        metadata.get("levelExam").foreach {
+            case le: java.util.Map[_, _] =>
+                validateLevelExam(le.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, metadata, errors)
+            case s: String =>
+                validateLevelExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, metadata, errors)
+            case other =>
+                println(s"[COMPETENCY-FRAMEWORK] levelExam unknown type: ${other.getClass} => $other")
+        }
+
+        if (errors.nonEmpty) {
+            throw new ClientException("ERR_COMPETENCY_FRAMEWORK_REVIEW", "Competency Level: " + errors.mkString("; "))
+        } else Right(())
+    }
+
+    private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
+        if (timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_LIMIT_NO).toString == TIME_LIMIT_YES) {
+            val duration: Map[String, AnyRef] = timeLimit.get(TIME_LIMIT_DURATION).collect {
+                case d: java.util.Map[_, _] => d.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+            }.getOrElse(Map.empty[String, AnyRef])
+
+            if (!duration.contains(TIME_LIMIT_VALUE)) errors += missingTimeLimitValue()
+            if (!duration.contains(TIME_LIMIT_UNIT))  errors += missingTimeLimitUnit()
+        }
+    }
+
+    private def validateLevelExam(exam: Map[String, AnyRef], metadata: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
+        if (!exam.contains(LEVEL_EXAM_COURSE_ID))
+            errors += missingLevelExamCourseId()
+
+        val passingCriteria = metadata
+            .get(PASSING_CRITERIA)
+            .map {
+                case pc: java.util.Map[_, _] => pc.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+                case s: String               => gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
+            }
+            .getOrElse(Map.empty[String, AnyRef])
+
+        val mustPass = passingCriteria.getOrElse(PASSING_CRITERIA_MUST_PASS, TIME_LIMIT_NO).toString
+        if (!PASSING_CRITERIA_VALID.contains(mustPass))
+            errors += invalidPassingCriteria(mustPass)
+    }
+
+    private def validateEntranceExam(exam: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
+        val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, TIME_LIMIT_NO).toString
+        if (!ENTRANCE_EXAM_VALID.contains(enabled))
+            errors += invalidEntranceExamEnabled(enabled)
+
+        if (enabled == TIME_LIMIT_YES) {
+            val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString
+            if (courseId.trim.isEmpty)
+                errors += missingEntranceExamCourseId()
+        }
+    }
+}

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -6,10 +6,12 @@ import org.sunbird.graph.dac.model.Node
 
 import scala.collection.JavaConverters._
 import com.google.gson.Gson
+import org.slf4j.LoggerFactory
 
 class CompetencyLevel extends CompetencyValidator {
 
     private val gson = new Gson()
+    val logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
     override def validate(node: Node): Either[List[String], Unit] = {
         val errors = scala.collection.mutable.ListBuffer[String]()
@@ -32,7 +34,7 @@ class CompetencyLevel extends CompetencyValidator {
             case s: String =>
                 validateTimeLimit(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
             case other =>
-                println(s"[COMPETENCY-FRAMEWORK] timeLimit unknown type: ${other.getClass} => $other")
+                logger.warn(s"[COMPETENCY-FRAMEWORK] timeLimit unknown type: ${other.getClass} => $other")
         }
 
         metadata.get("entranceExam").foreach {
@@ -41,7 +43,7 @@ class CompetencyLevel extends CompetencyValidator {
             case s: String =>
                 validateEntranceExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
             case other =>
-                println(s"[COMPETENCY-FRAMEWORK] entranceExam unknown type: ${other.getClass} => $other")
+                logger.warn(s"[COMPETENCY-FRAMEWORK] entranceExam unknown type: ${other.getClass} => $other")
         }
 
         metadata.get("levelExam").foreach {
@@ -50,7 +52,7 @@ class CompetencyLevel extends CompetencyValidator {
             case s: String =>
                 validateLevelExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, metadata, errors)
             case other =>
-                println(s"[COMPETENCY-FRAMEWORK] levelExam unknown type: ${other.getClass} => $other")
+                logger.warn(s"[COMPETENCY-FRAMEWORK] levelExam unknown type: ${other.getClass} => $other")
         }
 
         if (errors.nonEmpty) {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -4,72 +4,126 @@ import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
 import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
 import org.sunbird.content.competency.mgr.CompetencyManager.validateCourseExists
 import org.sunbird.common.exception.ClientException
+import org.sunbird.common.JsonUtils
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.OntologyEngineContext
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext
-
-import com.google.gson.Gson
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Try, Success, Failure}
 import org.slf4j.{Logger, LoggerFactory}
-
 
 class CompetencyLevel extends CompetencyValidator {
 
-    private val gson = new Gson()
     val logger: Logger =
         LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit = {
+    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Unit] = {
         implicit val parentNode: Node = node
         val errors = ListBuffer[String]()
-        val metadata = node.getMetadata.asScala.toMap
+        val metadata = node.getMetadata.asScala
 
-
-        metadata.get("timeLimit").foreach {
-            case tl: java.util.Map[_, _] =>
-                validateTimeLimit(tl.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, errors)
-            case s: String =>
-                validateTimeLimit(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
-            case other =>
-                logger.warn(s"[COMPETENCY-FRAMEWORK] timeLimit unknown type: ${other.getClass} => $other")
+        val validationFutures = ListBuffer[Future[Unit]]()
+        val timeLimit = metadata.getOrElse("timeLimit", null)
+        if (timeLimit != null) {
+            timeLimit match {
+                case tl: java.util.Map[_, _] =>
+                    validateTimeLimit(tl.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, errors)
+                case s: String =>
+                    parseJsonToMap(s, "timeLimit").foreach { timeLimitMap =>
+                        validateTimeLimit(timeLimitMap, errors)
+                    }
+                case other =>
+                    logger.warn(s"[COMPETENCY-LEVEL] timeLimit unknown type: ${other.getClass} => $other")
+                    errors += s"Invalid timeLimit type: ${other.getClass.getSimpleName}"
+            }
         }
 
-        metadata.get("entranceExam").foreach {
-            case ee: java.util.Map[_, _] =>
-                validateEntranceExam(ee.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, errors)
-            case s: String =>
-                validateEntranceExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, errors)
-            case other =>
-                logger.warn(s"[COMPETENCY-FRAMEWORK] entranceExam unknown type: ${other.getClass} => $other")
+        val entranceExam = metadata.getOrElse("entranceExam", null)
+        if (entranceExam != null) {
+            entranceExam match {
+                case ee: java.util.Map[_, _] =>
+                    val entranceExamFuture = validateEntranceExam(
+                        ee.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap,
+                        errors
+                    )
+                    validationFutures += entranceExamFuture
+                case s: String =>
+                    parseJsonToMap(s, "entranceExam").foreach { entranceExamMap =>
+                        val entranceExamFuture = validateEntranceExam(entranceExamMap, errors)
+                        validationFutures += entranceExamFuture
+                    }
+                case other =>
+                    logger.warn(s"[COMPETENCY-LEVEL] entranceExam unknown type: ${other.getClass} => $other")
+                    errors += s"Invalid entranceExam type: ${other.getClass.getSimpleName}"
+            }
         }
 
-        metadata.get("levelExam").foreach {
-            case le: java.util.Map[_, _] =>
-                validateLevelExam(le.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, metadata, errors)
-            case s: String =>
-                validateLevelExam(gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap, metadata, errors)
-            case other =>
-                logger.warn(s"[COMPETENCY-FRAMEWORK] levelExam unknown type: ${other.getClass} => $other")
+        val levelExam = metadata.getOrElse("levelExam", null)
+        if (levelExam != null) {
+            levelExam match {
+                case le: java.util.Map[_, _] =>
+                    val levelExamFuture = validateLevelExam(
+                        le.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap,
+                        metadata.toMap,
+                        errors
+                    )
+                    validationFutures += levelExamFuture
+                case s: String =>
+                    parseJsonToMap(s, "levelExam").foreach { levelExamMap =>
+                        val levelExamFuture = validateLevelExam(levelExamMap, metadata.toMap, errors)
+                        validationFutures += levelExamFuture
+                    }
+                case other =>
+                    logger.warn(s"[COMPETENCY-LEVEL] levelExam unknown type: ${other.getClass} => $other")
+                    errors += s"Invalid levelExam type: ${other.getClass.getSimpleName}"
+            }
         }
 
         if (errors.nonEmpty) {
-            throw new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Level: " + errors.mkString("; "))
+            Future.failed(
+                new ClientException("ERR_COMPETENCY_LEVEL", "Competency Level: " + errors.mkString("; "))
+            )
+        } else if (validationFutures.nonEmpty) {
+            Future.sequence(validationFutures).flatMap { _ =>
+                if (errors.nonEmpty) {
+                    Future.failed(
+                        new ClientException("ERR_COMPETENCY_LEVEL", "Competency Level: " + errors.mkString("; "))
+                    )
+                } else {
+                    Future.unit
+                }
+            }
+        } else {
+            Future.unit
+        }
+    }
+    private def parseJsonToMap(jsonString: String, fieldName: String): Option[Map[String, AnyRef]] = {
+        Try(JsonUtils.deserialize(jsonString, classOf[java.util.Map[String, AnyRef]])) match {
+            case Success(javaMap) => Some(javaMap.asScala.toMap)
+            case Failure(ex) =>
+                logger.error(s"[COMPETENCY-LEVEL] Failed to parse $fieldName JSON: $jsonString", ex)
+                None
         }
     }
 
     private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
-        if (timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_NO).toString == TIME_YES) {
+        val enabled = timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_NO).toString
+        if (enabled == TIME_YES) {
             val duration: Map[String, AnyRef] = timeLimit.get(TIME_LIMIT_DURATION).collect {
-                case d: java.util.Map[_, _] => d.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+                case d: java.util.Map[_, _] =>
+                    d.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
             }.getOrElse(Map.empty[String, AnyRef])
 
-            if (!duration.contains(TIME_LIMIT_VALUE) || duration(TIME_LIMIT_VALUE) == null || duration(TIME_LIMIT_VALUE).toString.trim.isEmpty) {
+            val value = duration.getOrElse(TIME_LIMIT_VALUE, "").toString.trim
+            val unit = duration.getOrElse(TIME_LIMIT_UNIT, "").toString.trim
+
+            if (value.isEmpty) {
                 errors += s"timeLimit.duration.$TIME_LIMIT_VALUE is required"
             }
 
-            if (!duration.contains(TIME_LIMIT_UNIT) || duration(TIME_LIMIT_UNIT) == null || duration(TIME_LIMIT_UNIT).toString.trim.isEmpty) {
+            if (unit.isEmpty) {
                 errors += s"timeLimit.duration.$TIME_LIMIT_UNIT is required"
             }
         }
@@ -79,11 +133,12 @@ class CompetencyLevel extends CompetencyValidator {
                                      exam: Map[String, AnyRef],
                                      metadata: Map[String, AnyRef],
                                      errors: ListBuffer[String]
-                                 )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
-        if (!exam.contains(LEVEL_EXAM_COURSE_ID)) {
+                                 )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
+        val courseId = exam.getOrElse(LEVEL_EXAM_COURSE_ID, "").toString.trim
+        if (courseId.isEmpty) {
             errors += missingLevelExamCourseId()
+            Future.unit
         } else {
-            val courseId = exam.getOrElse(LEVEL_EXAM_COURSE_ID, "").toString
             validateCourseExists(courseId, "Level Exam", errors)
         }
     }
@@ -91,15 +146,18 @@ class CompetencyLevel extends CompetencyValidator {
     private def validateEntranceExam(
                                         exam: Map[String, AnyRef],
                                         errors: ListBuffer[String]
-                                    )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
-        val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, "No").toString
+                                    )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Future[Unit] = {
+        val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, TIME_NO).toString
         if (enabled == TIME_YES) {
-            val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString
-            if (courseId.trim.isEmpty) {
+            val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString.trim
+            if (courseId.isEmpty) {
                 errors += missingEntranceExamCourseId()
+                Future.unit
             } else {
                 validateCourseExists(courseId, "Entrance Exam", errors)
             }
+        } else {
+            Future.unit
         }
     }
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -1,12 +1,15 @@
 package org.sunbird.content.competency.mgr.validator
+
 import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
 import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.dac.model.Node
+import org.sunbird.graph.OntologyEngineContext
 
 import scala.collection.JavaConverters._
 import com.google.gson.Gson
 import org.slf4j.{Logger, LoggerFactory}
+import scala.collection.mutable.ListBuffer
 
 class CompetencyLevel extends CompetencyValidator {
 
@@ -14,19 +17,8 @@ class CompetencyLevel extends CompetencyValidator {
     val logger: Logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
     override def validate(node: Node): Unit = {
-        val errors = scala.collection.mutable.ListBuffer[String]()
+        val errors = ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
-
-        REQUIRED_COMPETENCY_LEVEL_FIELDS.foreach { field =>
-            if (!metadata.contains(field) || metadata(field) == null || metadata(field).toString.trim.isEmpty) {
-                errors += s"Missing or empty required field: $field"
-            }
-        }
-
-        metadata.get("name").foreach { name =>
-            if (!VALID_LEVEL_NAMES.contains(name.toString))
-                errors += invalidLevelName(name.toString)
-        }
 
         metadata.get("timeLimit").foreach {
             case tl: java.util.Map[_, _] =>
@@ -60,43 +52,35 @@ class CompetencyLevel extends CompetencyValidator {
         }
     }
 
-    private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
+    private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
         if (timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_LIMIT_NO).toString == TIME_LIMIT_YES) {
             val duration: Map[String, AnyRef] = timeLimit.get(TIME_LIMIT_DURATION).collect {
                 case d: java.util.Map[_, _] => d.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
             }.getOrElse(Map.empty[String, AnyRef])
 
-            if (!duration.contains(TIME_LIMIT_VALUE)) errors += missingTimeLimitValue()
-            if (!duration.contains(TIME_LIMIT_UNIT))  errors += missingTimeLimitUnit()
+            if (!duration.contains(TIME_LIMIT_VALUE) || duration(TIME_LIMIT_VALUE) == null || duration(TIME_LIMIT_VALUE).toString.trim.isEmpty) {
+                errors += s"$TIME_LIMIT_VALUE is required"
+            }
+
+            if (!duration.contains(TIME_LIMIT_UNIT) || duration(TIME_LIMIT_UNIT) == null || duration(TIME_LIMIT_UNIT).toString.trim.isEmpty) {
+                errors += s"$TIME_LIMIT_UNIT is required"
+            }
         }
     }
 
-    private def validateLevelExam(exam: Map[String, AnyRef], metadata: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
-        if (!exam.contains(LEVEL_EXAM_COURSE_ID))
+    private def validateLevelExam(exam: Map[String, AnyRef], metadata: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
+        if (!exam.contains(LEVEL_EXAM_COURSE_ID)) {
             errors += missingLevelExamCourseId()
-
-        val passingCriteria = metadata
-            .get(PASSING_CRITERIA)
-            .map {
-                case pc: java.util.Map[_, _] => pc.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
-                case s: String               => gson.fromJson(s, classOf[java.util.Map[String, AnyRef]]).asScala.toMap
-            }
-            .getOrElse(Map.empty[String, AnyRef])
-
-        val mustPass = passingCriteria.getOrElse(PASSING_CRITERIA_MUST_PASS, TIME_LIMIT_NO).toString
-        if (!PASSING_CRITERIA_VALID.contains(mustPass))
-            errors += invalidPassingCriteria(mustPass)
+        }
     }
 
-    private def validateEntranceExam(exam: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {
-        val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, TIME_LIMIT_NO).toString
-        if (!ENTRANCE_EXAM_VALID.contains(enabled))
-            errors += invalidEntranceExamEnabled(enabled)
-
-        if (enabled == TIME_LIMIT_YES) {
+    private def validateEntranceExam(exam: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
+        val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, "No").toString
+        if (enabled == "Yes") {
             val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString
-            if (courseId.trim.isEmpty)
+            if (courseId.trim.isEmpty) {
                 errors += missingEntranceExamCourseId()
+            }
         }
     }
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -4,7 +4,6 @@ import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
 import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.dac.model.Node
-import org.sunbird.graph.OntologyEngineContext
 
 import scala.collection.JavaConverters._
 import com.google.gson.Gson
@@ -59,11 +58,11 @@ class CompetencyLevel extends CompetencyValidator {
             }.getOrElse(Map.empty[String, AnyRef])
 
             if (!duration.contains(TIME_LIMIT_VALUE) || duration(TIME_LIMIT_VALUE) == null || duration(TIME_LIMIT_VALUE).toString.trim.isEmpty) {
-                errors += s"$TIME_LIMIT_VALUE is required"
+                errors += s"timeLimit.duration.$TIME_LIMIT_VALUE is required"
             }
 
             if (!duration.contains(TIME_LIMIT_UNIT) || duration(TIME_LIMIT_UNIT) == null || duration(TIME_LIMIT_UNIT).toString.trim.isEmpty) {
-                errors += s"$TIME_LIMIT_UNIT is required"
+                errors += s"timeLimit.duration.$TIME_LIMIT_UNIT is required"
             }
         }
     }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -56,8 +56,8 @@ class CompetencyLevel extends CompetencyValidator {
         }
 
         if (errors.nonEmpty) {
-            throw new ClientException("ERR_COMPETENCY_FRAMEWORK_REVIEW", "Competency Level: " + errors.mkString("; "))
-        } else Right(())
+            throw new ClientException("ERR_COMPETENCY_FRAMEWORK", "Competency Level: " + errors.mkString("; "))
+        }
     }
 
     private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: scala.collection.mutable.ListBuffer[String]): Unit = {

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -2,22 +2,30 @@ package org.sunbird.content.competency.mgr.validator
 
 import org.sunbird.content.competency.mgr.constants.CompetencyConstants._
 import org.sunbird.content.competency.mgr.constants.CompetencyErrorMessages._
+import org.sunbird.content.competency.mgr.CompetencyManager.validateCourseExists
 import org.sunbird.common.exception.ClientException
 import org.sunbird.graph.dac.model.Node
+import org.sunbird.graph.OntologyEngineContext
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+
 import com.google.gson.Gson
 import org.slf4j.{Logger, LoggerFactory}
-import scala.collection.mutable.ListBuffer
+
 
 class CompetencyLevel extends CompetencyValidator {
 
     private val gson = new Gson()
-    val logger: Logger = LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
+    val logger: Logger =
+        LoggerFactory.getLogger("org.sunbird.content.competency.mgr.validator.CompetencyValidator")
 
-    override def validate(node: Node): Unit = {
+    override def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit = {
+        implicit val parentNode: Node = node
         val errors = ListBuffer[String]()
         val metadata = node.getMetadata.asScala.toMap
+
 
         metadata.get("timeLimit").foreach {
             case tl: java.util.Map[_, _] =>
@@ -67,18 +75,30 @@ class CompetencyLevel extends CompetencyValidator {
         }
     }
 
-    private def validateLevelExam(exam: Map[String, AnyRef], metadata: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
+    private def validateLevelExam(
+                                     exam: Map[String, AnyRef],
+                                     metadata: Map[String, AnyRef],
+                                     errors: ListBuffer[String]
+                                 )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
         if (!exam.contains(LEVEL_EXAM_COURSE_ID)) {
             errors += missingLevelExamCourseId()
+        } else {
+            val courseId = exam.getOrElse(LEVEL_EXAM_COURSE_ID, "").toString
+            validateCourseExists(courseId, "Level Exam", errors)
         }
     }
 
-    private def validateEntranceExam(exam: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
+    private def validateEntranceExam(
+                                        exam: Map[String, AnyRef],
+                                        errors: ListBuffer[String]
+                                    )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
         val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, "No").toString
         if (enabled == "Yes") {
             val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString
             if (courseId.trim.isEmpty) {
                 errors += missingEntranceExamCourseId()
+            } else {
+                validateCourseExists(courseId, "Entrance Exam", errors)
             }
         }
     }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyLevel.scala
@@ -60,7 +60,7 @@ class CompetencyLevel extends CompetencyValidator {
     }
 
     private def validateTimeLimit(timeLimit: Map[String, AnyRef], errors: ListBuffer[String]): Unit = {
-        if (timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_LIMIT_NO).toString == TIME_LIMIT_YES) {
+        if (timeLimit.getOrElse(TIME_LIMIT_ENABLED, TIME_NO).toString == TIME_YES) {
             val duration: Map[String, AnyRef] = timeLimit.get(TIME_LIMIT_DURATION).collect {
                 case d: java.util.Map[_, _] => d.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
             }.getOrElse(Map.empty[String, AnyRef])
@@ -93,7 +93,7 @@ class CompetencyLevel extends CompetencyValidator {
                                         errors: ListBuffer[String]
                                     )(implicit oec: OntologyEngineContext, ec: ExecutionContext, parentNode: Node): Unit = {
         val enabled = exam.getOrElse(ENTRANCE_EXAM_ENABLED, "No").toString
-        if (enabled == "Yes") {
+        if (enabled == TIME_YES) {
             val courseId = exam.getOrElse(ENTRANCE_EXAM_COURSE_ID, "").toString
             if (courseId.trim.isEmpty) {
                 errors += missingEntranceExamCourseId()

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -2,5 +2,5 @@ package org.sunbird.content.competency.mgr.validator
 import org.sunbird.graph.dac.model.Node
 
 trait CompetencyValidator {
-  def validate(node: Node): Unit
+    def validate(node: Node): Unit
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -1,6 +1,9 @@
 package org.sunbird.content.competency.mgr.validator
 import org.sunbird.graph.dac.model.Node
+import org.sunbird.graph.OntologyEngineContext
+
+import scala.concurrent.ExecutionContext
 
 trait CompetencyValidator {
-    def validate (node: Node): Unit
+    def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -2,5 +2,5 @@ package org.sunbird.content.competency.mgr.validator
 import org.sunbird.graph.dac.model.Node
 
 trait CompetencyValidator {
-    def validate(node: Node): Either[List[String], Unit]
+  def validate(node: Node): Unit
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -1,0 +1,6 @@
+package org.sunbird.content.competency.mgr.validator
+import org.sunbird.graph.dac.model.Node
+
+trait CompetencyValidator {
+    def validate(node: Node): Either[List[String], Unit]
+}

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -2,5 +2,5 @@ package org.sunbird.content.competency.mgr.validator
 import org.sunbird.graph.dac.model.Node
 
 trait CompetencyValidator {
-    def validate(node: Node): Unit
+    def validate (node: Node): Unit
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/competency/mgr/validator/CompetencyValidator.scala
@@ -1,9 +1,10 @@
 package org.sunbird.content.competency.mgr.validator
+
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.OntologyEngineContext
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 trait CompetencyValidator {
-    def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Unit
+    def validate(node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Unit]
 }

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
@@ -21,8 +21,9 @@ object PublishManager {
 	private val kfClient = new KafkaClient
 
 	def publish(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
-		val primaryCategory = node.getMetadata.getOrDefault("primaryCategory", "").asInstanceOf[String]
-		CompetencyManager.getValidator(primaryCategory).validate(node)
+        // Competency validation check
+        val validation: Future[Unit] = CompetencyManager.validateNode(node)
+
 		val identifier: String = node.getIdentifier
 		val mimeType = node.getMetadata.getOrDefault(ContentConstants.MIME_TYPE, "").asInstanceOf[String]
 		val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)
@@ -33,7 +34,19 @@ object PublishManager {
 		val publishType = request.getContext.getOrDefault(ContentConstants.PUBLISH_TYPE, "").asInstanceOf[String]
 		node.getMetadata.put(ContentConstants.PUBLISH_TYPE, publishType)
 
-		val publishFuture: Future[scala.collection.Map[String, AnyRef]] = mgr.publish(identifier, node)
+		val publishFuture = validation.flatMap { _ =>
+            val identifier: String = node.getIdentifier
+            val mimeType = node.getMetadata.getOrDefault(ContentConstants.MIME_TYPE, "").asInstanceOf[String]
+            val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)
+
+            val publishCheckList = request.getContext.getOrDefault(ContentConstants.PUBLIC_CHECK_LIST, List.empty[String]).asInstanceOf[List[String]]
+            if (publishCheckList.isEmpty) node.getMetadata.put(ContentConstants.PUBLIC_CHECK_LIST, null)
+
+            val publishType = request.getContext.getOrDefault(ContentConstants.PUBLISH_TYPE, "").asInstanceOf[String]
+            node.getMetadata.put(ContentConstants.PUBLISH_TYPE, publishType)
+
+            mgr.publish(identifier, node)
+        }
 		publishFuture.map(result => {
 			// Push Instruction Event - Learning code has logic to send publish instruction to different topics based on mimeTypes. That logic is not implemented here due to deprecation of samza jobs.
 			pushInstructionEvent(identifier, node)
@@ -101,5 +114,3 @@ object PublishManager {
 		edata.put(ContentConstants.CONTENT_TYPE, metadata.get(ContentConstants.CONTENT_TYPE))
 	}
 }
-
-

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
@@ -11,6 +11,7 @@ import org.sunbird.graph.dac.model.Node
 import org.sunbird.kafka.client.KafkaClient
 import org.sunbird.mimetype.factory.MimeTypeManagerFactory
 import org.sunbird.telemetry.util.LogTelemetryEventUtil
+import org.sunbird.content.competency.mgr.CompetencyManager
 
 import java.util
 import scala.concurrent.{ExecutionContext, Future}
@@ -20,6 +21,8 @@ object PublishManager {
 	private val kfClient = new KafkaClient
 
 	def publish(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
+		val primaryCategory = node.getMetadata().getOrDefault("primaryCategory", "").asInstanceOf[String]
+		CompetencyManager.getValidator(primaryCategory).validate(node)
 		val identifier: String = node.getIdentifier
 		val mimeType = node.getMetadata.getOrDefault(ContentConstants.MIME_TYPE, "").asInstanceOf[String]
 		val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/publish/mgr/PublishManager.scala
@@ -21,7 +21,7 @@ object PublishManager {
 	private val kfClient = new KafkaClient
 
 	def publish(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
-		val primaryCategory = node.getMetadata().getOrDefault("primaryCategory", "").asInstanceOf[String]
+		val primaryCategory = node.getMetadata.getOrDefault("primaryCategory", "").asInstanceOf[String]
 		CompetencyManager.getValidator(primaryCategory).validate(node)
 		val identifier: String = node.getIdentifier
 		val mimeType = node.getMetadata.getOrDefault(ContentConstants.MIME_TYPE, "").asInstanceOf[String]

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 object ReviewManager {
 
 	def review(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
-		val primaryCategory = node.getMetadata().getOrDefault("primaryCategory", "").asInstanceOf[String]
+		val primaryCategory = node.getMetadata.getOrDefault("primaryCategory", "").asInstanceOf[String]
 		CompetencyManager.getValidator(primaryCategory).validate(node)
 		val identifier: String = node.getIdentifier
 		val mimeType = node.getMetadata().getOrDefault("mimeType", "").asInstanceOf[String]

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
@@ -14,12 +14,16 @@ import scala.concurrent.{ExecutionContext, Future}
 object ReviewManager {
 
 	def review(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
-		val primaryCategory = node.getMetadata.getOrDefault("primaryCategory", "").asInstanceOf[String]
-		CompetencyManager.getValidator(primaryCategory).validate(node)
-		val identifier: String = node.getIdentifier
-		val mimeType = node.getMetadata().getOrDefault("mimeType", "").asInstanceOf[String]
-		val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)
-		val reviewFuture: Future[Map[String, AnyRef]] = mgr.review(identifier, node)
+		// Competency validation check
+        val validation: Future[Unit] = CompetencyManager.validateNode(node)
+
+		val reviewFuture = validation.flatMap { _ =>
+            val identifier = node.getIdentifier
+            val mimeType = node.getMetadata.getOrDefault("mimeType", "").asInstanceOf[String]
+            val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)
+            mgr.review(identifier, node)
+        }
+		
 		reviewFuture.map(result => {
 			val updateReq = new Request()
 			updateReq.setContext(request.getContext)
@@ -30,5 +34,3 @@ object ReviewManager {
 		}).flatMap(f => f)
 	}
 }
-
-

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/review/mgr/ReviewManager.scala
@@ -5,6 +5,7 @@ import org.sunbird.graph.OntologyEngineContext
 import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.nodes.DataNode
 import org.sunbird.mimetype.factory.MimeTypeManagerFactory
+import org.sunbird.content.competency.mgr.CompetencyManager
 
 import scala.collection.Map
 import scala.collection.JavaConverters._
@@ -13,6 +14,8 @@ import scala.concurrent.{ExecutionContext, Future}
 object ReviewManager {
 
 	def review(request: Request, node: Node)(implicit oec: OntologyEngineContext, ec: ExecutionContext): Future[Response] = {
+		val primaryCategory = node.getMetadata().getOrDefault("primaryCategory", "").asInstanceOf[String]
+		CompetencyManager.getValidator(primaryCategory).validate(node)
 		val identifier: String = node.getIdentifier
 		val mimeType = node.getMetadata().getOrDefault("mimeType", "").asInstanceOf[String]
 		val mgr = MimeTypeManagerFactory.getManager(node.getObjectType, mimeType)


### PR DESCRIPTION
### Summary
- Introduced validation layer for Competency Framework nodes during review/publish lifecycle.
- Added strict checks on required fields and their values, ensuring schema compliance.
### Details
- Implemented CompetencyFramework validator extending CompetencyValidator.
    Validation includes:
    - Required fields: sector, signupBy, enrollmentType
    - sector: must contain valid name and domain (matches constants in CompetencyConstants)
    - signupBy: restricted to Admin | User
    - enrollmentType: restricted to Full Enrollment | Entrance Exam Based | Progress Based
    - Errors are collected and raised as ClientException with descriptive messages.
    - Extracted constants into CompetencyConstants
    - Added CompetencyManager to centralize validator resolution by primaryCategory (e.g., "Competency Framework", "Competency Level").